### PR TITLE
Installs and sets up NTP deamon.

### DIFF
--- a/ansible/roles/base/defaults/main.yml
+++ b/ansible/roles/base/defaults/main.yml
@@ -3,3 +3,4 @@
 # System
 timezone: America/New_York
 locale: en_US.UTF-8
+ntp_servers: []

--- a/ansible/roles/base/handlers/main.yml
+++ b/ansible/roles/base/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: restart ntp
+  sudo: yes
+  service: name=ntp state=restarted

--- a/ansible/roles/base/tasks/install-common-tools.yml
+++ b/ansible/roles/base/tasks/install-common-tools.yml
@@ -4,6 +4,7 @@
   sudo: yes
   apt: name={{ item }} state=latest
   with_items:
+    - ntp
     - git
     - curl
     - mailutils

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -3,4 +3,6 @@
 - include: configure-system.yml
 - include: update-system.yml
 - include: install-common-tools.yml
+- include: setup-ntp.yml
+  when: ntp_servers
 - include: setup-user.yml

--- a/ansible/roles/base/tasks/setup-ntp.yml
+++ b/ansible/roles/base/tasks/setup-ntp.yml
@@ -1,0 +1,29 @@
+---
+
+- name: NTP | Check configuration cleanup lock
+  sudo: yes
+  stat: path=/etc/ntp.conf.lock
+  register: ntp_lock
+
+- name: NTP | Cleanup configuration from default servers
+  sudo: yes
+  lineinfile: >
+    dest=/etc/ntp.conf
+    regexp=^server
+    state=absent
+    backup=yes
+  when: not ntp_lock.stat.exists
+  register: ntp_conf_cleaned
+
+- name: NTP | Lock configuration cleanup
+  sudo: yes
+  file: path=/etc/ntp.conf.lock state=touch
+  when: ntp_conf_cleaned.changed
+
+- name: NTP | Configure provided NTP servers
+  sudo: yes
+  lineinfile: >
+    dest=/etc/ntp.conf
+    line="server {{ item }}"
+  with_items: ntp_servers
+  notify: restart ntp


### PR DESCRIPTION
Base role:
 - Installs ntp deamon
 - Provides functionality for overriding default ntp servers

By default, it will install NTP deamon that connects to default servers, f.e `0.ubuntu.pool.ntp.org`.
When `ntp_servers` is set, the role removes all default servers from the configuration and adds servers provided in the variable.

For example, here's configuration from [amazon NTP servers](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html):

```yml
ntp_servers:
 - 0.amazon.pool.ntp.org iburst
 - 1.amazon.pool.ntp.org iburst
 - 2.amazon.pool.ntp.org iburst
 - 3.amazon.pool.ntp.org iburst
```