### PR TITLE
Fixes international setup.

### DIFF
--- a/ansible/group_vars/all/app-environment.yml
+++ b/ansible/group_vars/all/app-environment.yml
@@ -4,9 +4,6 @@
 app_environment:
   - { option: DS_ENVIRONMENT, value: local }
   - { option: DS_APP_ROOT, value: "{{ app_root }}" }
-  - { option: DS_DB_MASTER_NAME, value: "{{ app_user }}" }
-  - { option: DS_DB_MASTER_USER, value: "root" }
-  - { option: DS_DB_MASTER_HOST, value: 127.0.0.1 }
   - { option: DS_HOSTNAME, value: "{{ app_host }}" }
   - { option: DS_INSECURE_PORT, value: 80 }
   - { option: DS_SECURE_PORT, value: 443 }


### PR DESCRIPTION
Removes DS_DB env settings so it will get overridden by `settings.php` defaults.
Before that, all international sites were using `dosomething` as a database: https://github.com/sergii-tkachenko/dosomething/blob/dev/config/settings.php#L15

Fixes DoSomething/ansible-dosomething#4.